### PR TITLE
IBM Plex font as submodule, use Plex Mono in Emacs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".fonts/IBM-Plex"]
+	path = home/.fonts/IBM-Plex
+	url = https://github.com/IBM/plex

--- a/home/.emacs
+++ b/home/.emacs
@@ -21,9 +21,9 @@
 (blink-cursor-mode 1)
 
 
-(set-default-font "Inconsolata-10")
+(set-default-font "IBMPlexMono-9")
 (add-to-list 'default-frame-alist
-             '(font . "Inconsolata-10"))
+             '(font . "IBMPlexMono-9"))
 (setq mouse-autoselect-window nil) ;; focus follows mouse off
 (setq sentence-end-double-space nil) ;; sentences end with a single space
 (setq show-paren-delay 0)
@@ -37,7 +37,6 @@
 (setq buffer-file-coding-system 'unix) ;; DOES THIS WORK??
 (setq visible-bell t)
 (setq compilation-scroll-output t)
-(set-default-font "Inconsolata 10")
 (setq comment-column 40)
 (setq blink-cursor-blinks -1)
 (setq debug-on-error t)


### PR DESCRIPTION
This adds the IBM Plex repository as a submodule inside the
home/.fonts directory. This then sets the default font for Emacs to be
IBMPlexMono. This should solve the problem of having reproducible
fonts in this dotfiles environment (possibly after requiring fc-cache
to be run once).

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@gmail.com>